### PR TITLE
Add --extra-libs="-ldl" and use hyphenated aac flag

### DIFF
--- a/ffmpeg/Dockerfile
+++ b/ffmpeg/Dockerfile
@@ -57,8 +57,8 @@ RUN curl -L https://webm.googlecode.com/files/libvpx-v1.3.0.tar.bz2 | tar xjf - 
 
 RUN	curl -L http://ffmpeg.org/releases/ffmpeg-2.7.2.tar.bz2 | tar xjf - && \
 	cd ffmpeg-2.7.2 && \
-	./configure --enable-avfilter --enable-version3 --enable-libopencore-amrnb --enable-libopencore-amrwb \
-		--enable-libvpx --enable-libfdk_aac --enable-libmp3lame --enable-libtheora --enable-libvorbis \
+	./configure --extra-libs="-ldl" --enable-avfilter --enable-version3 --enable-libopencore-amrnb --enable-libopencore-amrwb \
+		--enable-libvpx --enable-libfdk-aac --enable-libmp3lame --enable-libtheora --enable-libvorbis \
 		--enable-libx264 --enable-libxvid --enable-gpl --enable-postproc --enable-nonfree --enable-shared && \
 	make && make install && \
 	ldconfig && \


### PR DESCRIPTION
The internets claim that `--enable-libfdk-aac` is the correct flag. I tested with both the hyphen and underscore and the output from `./configure` for both had AAC in the `External libraries` and `Enabled decoders` section, so I think either works. Updating it to be more "correct", though, and avoid confusion.

Internally we've also tacked on an `--extra-libs="-ldl"` to our `./configure`; I've added that in, too. Lots of FFmpeg configurations I've found have it as well, so I think it's alright, but feel free to challenge the need for it.
