### PR TITLE
Upgrade pip

### DIFF
--- a/opencv/Dockerfile
+++ b/opencv/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
     gfortran \
     libatlas-base-dev \
     python \
-    python-dev
+    python-dev \
+    wget
 
 # pip
 RUN wget https://bootstrap.pypa.io/get-pip.py
@@ -54,7 +55,6 @@ RUN apt-get install -y libboost-all-dev --fix-missing
 RUN echo LC_ALL=C >> /etc/environment
 
 # Install VLFeat
-RUN apt-get install -y wget
 RUN wget http://www.vlfeat.org/download/vlfeat-0.9.20-bin.tar.gz
 RUN tar zxvf vlfeat-0.9.20-bin.tar.gz
 Run rm vlfeat-0.9.20-bin.tar.gz

--- a/opencv/Dockerfile
+++ b/opencv/Dockerfile
@@ -8,8 +8,11 @@ RUN apt-get update && apt-get install -y \
     gfortran \
     libatlas-base-dev \
     python \
-    python-dev \
-    python-pip
+    python-dev
+
+# pip
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python get-pip.py && rm get-pip.py
 
 # Python stack
 COPY ./requirements.txt /root/


### PR DESCRIPTION
apt-get installs a criminally old version of pip:

```
root@d771c854c9bc:~# pip --version
pip 1.5.4 from /usr/lib/python2.7/dist-packages (python 2.7)
```

This old version doesn't allow us to add other pypi servers in the same way. Instead we should download `get-pip.py` and install with that, which should keep pip updated in the container. The change currently installs pip 7.1.2

```
root@f2489a192973:/opencv# pip --version
pip 7.1.2 from /usr/local/lib/python2.7/dist-packages (python 2.7)
```
