### PR TITLE
[ffmpeg-gpu] Switch to versioned FFmpeg (3.3.2)

### DIFF
--- a/ffmpeg-gpu/Dockerfile
+++ b/ffmpeg-gpu/Dockerfile
@@ -40,14 +40,15 @@ RUN curl -L https://github.com/mstorsjo/fdk-aac/archive/v0.1.5.tar.gz | tar zxf 
     cd .. && \
     rm -rf fdk-aac-0.1.5
 
-RUN git clone https://github.com/FFmpeg/FFmpeg --depth 1 && \
-    cd FFmpeg && \
+RUN curl -L http://ffmpeg.org/releases/ffmpeg-3.3.2.tar.bz2 | tar xjf - && \
+    cd ffmpeg-3.3.2 && \
     ./configure --enable-avfilter --enable-version3 --enable-libopencore-amrnb --enable-libopencore-amrwb \
         --enable-libvpx --enable-libfdk-aac --enable-libmp3lame --enable-libtheora --enable-libvorbis \
         --enable-libx264 --enable-libxvid --enable-gpl --enable-postproc --enable-nonfree --enable-shared \
         --enable-libx265 --enable-libopus --enable-libass --enable-libfreetype --enable-nvenc \
         --enable-cuda --enable-cuvid --extra-cflags=-I/usr/local/cuda/include \
-        --extra-cflags=-I/usr/local/include --extra-ldflags=-L/usr/local/cuda/lib64 && \
+        --extra-cflags=-I/usr/local/include --extra-ldflags=-L/usr/local/cuda/lib64 \
+        --enable-libnpp && \
     make -j8 && make install && \
     ldconfig && \
     cd tools && \
@@ -55,7 +56,7 @@ RUN git clone https://github.com/FFmpeg/FFmpeg --depth 1 && \
     cp qt-faststart /usr/local/bin && \
     ldconfig && \
     cd ../.. && \
-    rm -rf FFmpeg
+    rm -rf ffmpeg-3.3.2
 
 RUN curl -L http://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-10.46.tar.gz | tar zxf - && \
     cd Image-ExifTool-10.46 && \


### PR DESCRIPTION
[hudl/ffmpeg-gpu:3.3.2](https://hub.docker.com/r/hudl/ffmpeg-gpu/tags/) has been pushed to Docker Hub and it'll let you use CUVID-based [resizing and cropping](https://github.com/FFmpeg/FFmpeg/blob/ff3084606c09911cdd3b6d6b588c47b9e71acea3/libavcodec/cuvid.c#L823-L836).

Cropping without the GPU (**50 fps**) - `crop=[width]:[height]:[crop_x]:[crop_y]`:
```
nvidia-docker run -v /data/:/data hudl/ffmpeg-gpu:3.3.2 -y -i /data/input.mp4 -filter:v 'crop=3840:400:3840:440' -preset slow /data/output.mp4
```

Cropping with the GPU (**419 fps**) - `[top]x[bottom]x[left]x[right]'`:
```
nvidia-docker run -v /data/:/data hudl/ffmpeg-gpu:3.3.2 -hwaccel cuvid -c:v h264_cuvid -crop '440x240x0x0' -y -i /data/input.mp4 -an -c:v h264_nvenc -preset slow /data/output.mp4
```

Scaling without the GPU (**93 fps**):
```
nvidia-docker run -v /data/:/data hudl/ffmpeg-gpu:3.3.2 -y -i /data/input.mp4 -filter:v scale=1920:480,setsar=1:1 -preset slow /data/output.mp4
```

Scaling with the GPU (**722 fps**):
```
sudo nvidia-docker run -v /data/:/data hudl/ffmpeg-gpu:3.3.2 -hwaccel cuvid -c:v h264_cuvid -resize '1920x480' -y -i /data/input.mp4 -an -c:v h264_nvenc -preset slow /data/output.mp4
```